### PR TITLE
Use new CDN urls for README badges

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,8 +1,8 @@
-![](https://jhbadge.de/?evt=ber&year=2019) [![](https://jhbadge.de/?type=view-presentation&evt=ber&year=2018)](https://media.ccc.de/v/jh19-fahrplandatengarten)
+![](https://i.jhbadge.com/?evt=ber&year=2019) [![](https://i.jhbadge.com/?type=view-presentation&evt=ber&year=2018)](https://media.ccc.de/v/jh19-fahrplandatengarten)
 
 and
 
-![](https://jhbadge.de/?evt=ulm&year=2019) [![](https://jhbadge.de/?type=view-presentation&evt=ulm&year=2019)](https://media.ccc.de/v/currently-not-published)
+![](https://i.jhbadge.com/?evt=ulm&year=2019) [![](https://i.jhbadge.com/?type=view-presentation&evt=ulm&year=2019)](https://media.ccc.de/v/currently-not-published)
 
 # FahrplanDatenGarten
 We  ❤️  Deutsche Bahn

--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
 
 and
 
-![](https://i.jhbadge.com/?evt=ulm&year=2019) [![](https://i.jhbadge.com/?type=view-presentation&evt=ulm&year=2019)](https://media.ccc.de/v/currently-not-published)
+![](http://jhbadge.marvnethosted.com/?evt=ulm&year=2019) [![](http://jhbadge.marvnethosted.com/?type=view-presentation&evt=ulm&year=2019)](https://media.ccc.de/v/currently-not-published)
 
 # FahrplanDatenGarten
 We  ❤️  Deutsche Bahn

--- a/README.md
+++ b/README.md
@@ -1,8 +1,8 @@
-![](http://jhbadge.marvnethosted.com/?evt=ber&year=2019) [![](http://jhbadge.marvnethosted.com/?type=view-presentation&evt=ber&year=2018)](https://media.ccc.de/v/jh19-fahrplandatengarten)
+![](https://jhbadge.freetls.fastly.net/?evt=ber&year=2019) [![](https://jhbadge.freetls.fastly.net/?type=view-presentation&evt=ber&year=2018)](https://media.ccc.de/v/jh19-fahrplandatengarten)
 
 and
 
-![](http://jhbadge.marvnethosted.com/?evt=ulm&year=2019) [![](http://jhbadge.marvnethosted.com/?type=view-presentation&evt=ulm&year=2019)](https://media.ccc.de/v/currently-not-published)
+![](https://jhbadge.freetls.fastly.net/?evt=ulm&year=2019) [![](https://jhbadge.freetls.fastly.net/?type=view-presentation&evt=ulm&year=2019)](https://media.ccc.de/v/currently-not-published)
 
 # FahrplanDatenGarten
 We  ❤️  Deutsche Bahn

--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-![](https://i.jhbadge.com/?evt=ber&year=2019) [![](https://i.jhbadge.com/?type=view-presentation&evt=ber&year=2018)](https://media.ccc.de/v/jh19-fahrplandatengarten)
+![](http://jhbadge.marvnethosted.com/?evt=ber&year=2019) [![](http://jhbadge.marvnethosted.com/?type=view-presentation&evt=ber&year=2018)](https://media.ccc.de/v/jh19-fahrplandatengarten)
 
 and
 


### PR DESCRIPTION
I am together with @niklasschroetler the maintainer of the Github Jugend hackt-Badges. We now use a new CDN, which can be found under the domain "i.jhbadge.com".  (However, the parameters and paths are still the same, backward compatibility is of course also guaranteed.)