### PR TITLE
Plot as image

### DIFF
--- a/FahrplanDatenGarten/verspaeti/templates/verspaeti/home.html
+++ b/FahrplanDatenGarten/verspaeti/templates/verspaeti/home.html
@@ -14,13 +14,7 @@
                     <p class="card-header-title">Versp&auml;tung heute</p>
                 </div>
                 <div class="card-content">
-                    <ul class="flex-list top-vertical content-center center">
-                        <li class="border-box">
-                            {% autoescape off %}
-                                {{ plot_div }}
-                            {% endautoescape %}
-                        </li>
-                    </ul>
+                    <img src="data:image/png;base64,{{ plot_image_base64 }}" />
                 </div>
             </div>
             <div class="column card is-3 is-offset-1">

--- a/FahrplanDatenGarten/verspaeti/views.py
+++ b/FahrplanDatenGarten/verspaeti/views.py
@@ -1,7 +1,9 @@
+import base64
+from io import BytesIO
+
 from django.core.cache import cache
 from django.views.generic import TemplateView
-from plotly.graph_objs import Pie
-from plotly.offline import plot
+from matplotlib import pyplot
 
 
 class IndexView(TemplateView):
@@ -11,20 +13,33 @@ class IndexView(TemplateView):
         context = super().get_context_data(**kwargs)
         verspaeti_data_cache = cache.get('verspaeti_data')
         if verspaeti_data_cache is not None:
-            colors = ['#63a615', '#ec0016']
-            labels = ['Pünktlich', 'Zu spät']
+            colors = ('#63a615', '#ec0016')
+            labels = ('Pünktlich', 'Zu spät')
             values = [
                 verspaeti_data_cache['num_current_journeys'] -
                 verspaeti_data_cache['num_delayed_journeys'],
                 verspaeti_data_cache['num_delayed_journeys']]
-            plot_div = plot(
-                [Pie(
-                    labels=labels,
-                    values=values,
-                    marker=dict(colors=colors))],
-                output_type='div')
+            plot_figure, plot_axes = pyplot.subplots(figsize=(5, 6))
 
-            context['plot_div'] = plot_div
+            plot_wedges, _, plot_autotexts = pyplot.pie(
+                values,
+                colors=colors,
+                autopct='%1.1f%%')
+
+            plot_axes.legend(
+                plot_wedges,
+                labels,
+                loc="lower center",
+                fontsize="xx-large",
+                bbox_to_anchor=(0.5, -0.1)
+            )
+            pyplot.setp(plot_autotexts, size=20)
+            pyplot.axis('equal')
+            plot_temporary_file = BytesIO()
+            pyplot.savefig(plot_temporary_file, format='png')
+            context['plot_image_base64'] = base64.b64encode(
+                plot_temporary_file.getvalue()).decode('utf-8')
+
             context['journeys_delayed'] = verspaeti_data_cache['num_delayed_journeys'],
             context['biggest_delay_name'] = verspaeti_data_cache['biggest_delay_name']
             context['biggest_delay_time'] = verspaeti_data_cache['biggest_delay_time']

--- a/FahrplanDatenGarten/verspaeti/views.py
+++ b/FahrplanDatenGarten/verspaeti/views.py
@@ -1,9 +1,5 @@
-import base64
-from io import BytesIO
-
 from django.core.cache import cache
 from django.views.generic import TemplateView
-from matplotlib import pyplot
 
 
 class IndexView(TemplateView):
@@ -13,37 +9,12 @@ class IndexView(TemplateView):
         context = super().get_context_data(**kwargs)
         verspaeti_data_cache = cache.get('verspaeti_data')
         if verspaeti_data_cache is not None:
-            colors = ('#63a615', '#ec0016')
-            labels = ('Pünktlich', 'Zu spät')
-            values = [
-                verspaeti_data_cache['num_current_journeys'] -
-                verspaeti_data_cache['num_delayed_journeys'],
-                verspaeti_data_cache['num_delayed_journeys']]
-            plot_figure, plot_axes = pyplot.subplots(figsize=(5, 6))
-
-            plot_wedges, _, plot_autotexts = pyplot.pie(
-                values,
-                colors=colors,
-                autopct='%1.1f%%')
-
-            plot_axes.legend(
-                plot_wedges,
-                labels,
-                loc="lower center",
-                fontsize="xx-large",
-                bbox_to_anchor=(0.5, -0.1)
-            )
-            pyplot.setp(plot_autotexts, size=20)
-            pyplot.axis('equal')
-            plot_temporary_file = BytesIO()
-            pyplot.savefig(plot_temporary_file, format='png')
-            context['plot_image_base64'] = base64.b64encode(
-                plot_temporary_file.getvalue()).decode('utf-8')
 
             context['journeys_delayed'] = verspaeti_data_cache['num_delayed_journeys'],
             context['biggest_delay_name'] = verspaeti_data_cache['biggest_delay_name']
             context['biggest_delay_time'] = verspaeti_data_cache['biggest_delay_time']
             context['average_delay'] = verspaeti_data_cache['average_delay']
+            context['plot_image_base64'] = verspaeti_data_cache['plot_image_base64']
         else:
             context['error_message'] = "Wir rechnen noch gerade die Statistiken zusammen, bitte versuche es in ein paar Minuten erneut. Wenn das Problem bestehen bleibt, melde dich bitte per E-Mail an bug_web<at>fahrplandatengarten.de"
         return context

--- a/requirements.txt
+++ b/requirements.txt
@@ -8,10 +8,11 @@ celery~=4.4.7
 redis~=3.5.3
 pytz==2020.1
 psycopg2-binary~=2.8.6
-plotly~=4.10.0
 -r FahrplanDatenGarten/netzkarte/requirements.txt
 pyhafas==0.2.0
 
 lxml~=4.5.2
 django-redis~=4.12.1
 django-countries~=6.1.3
+matplotlib~=3.3.2
+numpy~=1.19.2


### PR DESCRIPTION
With plotly the `verspaeti`-page has as size of 2.99 MB and also the chart is small.

Matplotlib generates an image which is embedded in the website. With that the page only has a size of ~30KB.